### PR TITLE
Fix path handling for git stage compression

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -117,7 +117,9 @@ const compressStageFiles = (editorPath: string) => {
             )
             return
         }
-        files.forEach(f => compressImage(Uri.parse(`${editorPath}/${f}`)))
+        files.forEach(f =>
+            compressImage(Uri.file(path.join(editorPath, f)))
+        )
     } catch(err) {
         vscode.window.showErrorMessage(
             `TinyPNG: ${(err as Error).message}`


### PR DESCRIPTION
## Summary
- ensure compressGitStage uses Uri.file to create valid URIs

## Testing
- `npm test` *(fails: Cannot find type definition file for 'glob')*